### PR TITLE
Delete link to blog post

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,6 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://tolomaps.github.io" # the base hostname & protocol for your site
 twitter_username: tolomaps
 github_username:  tolomaps
-post_url: "www.tolomaps.github.io/posts/"
 
 # Build settings
 markdown: kramdown

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://tolomaps.github.io" # the base hostname & protocol for your site
 twitter_username: tolomaps
 github_username:  tolomaps
+post_url: "www.tolomaps.github.io/posts/"
 
 # Build settings
 markdown: kramdown

--- a/_site/feed.xml
+++ b/_site/feed.xml
@@ -6,8 +6,8 @@
 </description>
     <link>http://tolomaps.github.io/</link>
     <atom:link href="http://tolomaps.github.io/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Mon, 23 Nov 2015 12:07:24 -0600</pubDate>
-    <lastBuildDate>Mon, 23 Nov 2015 12:07:24 -0600</lastBuildDate>
+    <pubDate>Mon, 23 Nov 2015 17:13:30 -0600</pubDate>
+    <lastBuildDate>Mon, 23 Nov 2015 17:13:30 -0600</lastBuildDate>
     <generator>Jekyll v3.0.0</generator>
     
       <item>
@@ -15,9 +15,6 @@
         <description>&lt;p&gt;&lt;br /&gt;
 &lt;strong&gt;About:&lt;/strong&gt;
 This is a piece for my Graphic Design in Cartography class. The assignment was to make an infographic with a bivariate map.&lt;/p&gt;
-
-&lt;p&gt;&lt;strong&gt;Process:&lt;/strong&gt;
-Read about &lt;a href=&quot;/blog/tumblr/2015/10/22/creating-a-bivariate-choropleth-color-scheme.html&quot;&gt;my process for creating a bivariate choropleth color scheme&lt;/a&gt;.&lt;/p&gt;
 
 &lt;p&gt;&lt;strong&gt;Background:&lt;/strong&gt;
 In 1971, Congress passed a bipartisan bill that would have “established a network of nationally funded, locally administered, comprehensive child care centers, which were to provide quality education, nutrition, and medical services.” And then Nixon vetoed it, because he said that children should be raised by family (read: women shouldn’t work). We were so close to universal public child care. It’s never been on the table since then, even though we provide free, public education to all children starting in kindergarten. Why shouldn’t we start earlier?&lt;/p&gt;

--- a/_site/feed.xml
+++ b/_site/feed.xml
@@ -6,8 +6,8 @@
 </description>
     <link>http://tolomaps.github.io/</link>
     <atom:link href="http://tolomaps.github.io/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Mon, 23 Nov 2015 00:42:32 -0600</pubDate>
-    <lastBuildDate>Mon, 23 Nov 2015 00:42:32 -0600</lastBuildDate>
+    <pubDate>Mon, 23 Nov 2015 12:07:24 -0600</pubDate>
+    <lastBuildDate>Mon, 23 Nov 2015 12:07:24 -0600</lastBuildDate>
     <generator>Jekyll v3.0.0</generator>
     
       <item>

--- a/_site/portfolio/2015/11/20/the-real-cost-of-child-care.html
+++ b/_site/portfolio/2015/11/20/the-real-cost-of-child-care.html
@@ -58,9 +58,6 @@
 <strong>About:</strong>
 This is a piece for my Graphic Design in Cartography class. The assignment was to make an infographic with a bivariate map.</p>
 
-<p><strong>Process:</strong>
-Read about <a href="/blog/tumblr/2015/10/22/creating-a-bivariate-choropleth-color-scheme.html">my process for creating a bivariate choropleth color scheme</a>.</p>
-
 <p><strong>Background:</strong>
 In 1971, Congress passed a bipartisan bill that would have “established a network of nationally funded, locally administered, comprehensive child care centers, which were to provide quality education, nutrition, and medical services.” And then Nixon vetoed it, because he said that children should be raised by family (read: women shouldn’t work). We were so close to universal public child care. It’s never been on the table since then, even though we provide free, public education to all children starting in kindergarten. Why shouldn’t we start earlier?</p>
 

--- a/portfolio/_posts/2015-11-20-the-real-cost-of-child-care.md
+++ b/portfolio/_posts/2015-11-20-the-real-cost-of-child-care.md
@@ -10,9 +10,6 @@ alt: The Real Cost of Childcare infographic
 **About:**
 This is a piece for my Graphic Design in Cartography class. The assignment was to make an infographic with a bivariate map.
 
-**Process:**
-Read about [my process for creating a bivariate choropleth color scheme]({% post_url 2015-10-22-creating-a-bivariate-choropleth-color-scheme %}).
-
 **Background:**
 In 1971, Congress passed a bipartisan bill that would have “established a network of nationally funded, locally administered, comprehensive child care centers, which were to provide quality education, nutrition, and medical services.” And then Nixon vetoed it, because he said that children should be raised by family (read: women shouldn’t work). We were so close to universal public child care. It’s never been on the table since then, even though we provide free, public education to all children starting in kindergarten. Why shouldn’t we start earlier?
 


### PR DESCRIPTION
The Jekyll site is having trouble building when I link to the blog posts. I deleted the link from one of my portfolio pages to see if that solves it.
